### PR TITLE
Enable custom hostnames for branch runners

### DIFF
--- a/moj-docker-deploy/apps/branchrunner.sls
+++ b/moj-docker-deploy/apps/branchrunner.sls
@@ -68,9 +68,14 @@ include:
     - mode: 644
     - template: jinja
     - context:
-      server_name: '{{branch_name}}.{{ salt['pillar.get']('master_zone') }}'
+      server_name: '{{branch_name}}.{{
+        salt['pillar.get'](
+          'branch_runner:container_base_hostname',
+          default=salt['pillar.get']('master_zone')
+        )
+      }}'
       branch_name: '{{branch_name}}'
-      appdata: 
+      appdata:
         branchbuilder: True
         assets_host_path: '/{{branch_name}}/'
         containers:


### PR DESCRIPTION
We don't always want branch hosts to live under master_zone, so allow
customisation of the base hostname.

This mirrors ministryofjustice/money-to-prisoners-deploy#15 and
ministryofjustice/template-deploy#158.
