### PR TITLE
Use tutum/cleanup to remove unused images

### DIFF
--- a/moj-docker-deploy/apps/container-cleanup.sls
+++ b/moj-docker-deploy/apps/container-cleanup.sls
@@ -1,0 +1,22 @@
+include:
+  - docker
+
+{% import 'apps/libs.sls' as macros with context %}
+
+{{ macros.create_container_config('tutum_cleanup', {
+  'name': 'tutum/cleanup',
+  'tag': 'v0.16.21',
+  'registry': None,
+  'docker_args': '--privileged',
+  'volumes': {
+    '/var/run': {
+      'host': '/var/run',
+      'container': '/var/run',
+    },
+    '/var/lib/docker': {
+      'host': '/var/lib/docker',
+      'container': '/var/lib/docker',
+    },
+  },
+}) }}
+{{ macros.setup_container_environment_variables('tutum_cleanup', {}) }}

--- a/moj-docker-deploy/apps/containers.sls
+++ b/moj-docker-deploy/apps/containers.sls
@@ -2,6 +2,7 @@ include:
   - .environment
   - .proxied-containers
   - .nonproxied-containers
+  - .container-cleanup
 
 HOME:
   environ.setenv:


### PR DESCRIPTION
[tutum/cleanup](https://github.com/tutumcloud/cleanup) allows us to easily remove unused images regularly, which will hopefully reduce our inode usage.

The tutum/cleanup container doesn't remove containers, and runs as a daemon pulling every second by default.

This reproduces ministryofjustice/template-deploy#157
