### PR TITLE
Add ability to cluster containers with other hosts containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
 
+* Enable clustering of containers with containers in other EC2 instances
 * Fix macro calls introduced for nginx logs
 
 ## v1.0.6

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ For more help in resolving problems and errors, see the [Template Deploy Trouble
 - [ports](#ports)
 - [volumes](#volumes)
 - [envvars](#envvars)
+- [enable_clustering](#enable_clustering)
+- [cluster_nodes_prefix](#cluster_nodes_prefix)
 
 ####[Non-Proxied Containers Settings](#non-proxied-containers-settings-subsection)
 
@@ -246,6 +248,22 @@ Note you get some free variables for database details etc, the following will be
 - *DB_USERNAME*: The RDS username set in the cloudformation yaml
 - *DB_PASSWORD*: The RDS password set in the cloudformation yaml
 - *DATABASE_URL*: db-engine://db-user:db-password@db-host:db-port/db-name
+
+#### enable\_clustering
+
+When set to True, clustering of containers with ports exposed on their hosts will be enabled. In practice, this means that other EC2 hosts and containers DNS resolvable inside a container, and a list of nodes will be exposed via environmental variables. See https://github.com/ministryofjustice/template-deploy#clustering_containers for more details.
+
+```yaml
+	enable_clustering: True
+```
+
+#### cluster\_nodes\_prefix
+
+To add a prefix to cluster nodes lists.
+
+```yaml
+	cluster_nodes_prefix: 'someprefix-'
+```
 
 ------------------------------------------------------
 ###Non-proxied Containers Settings Subsection

--- a/moj-docker-deploy/apps/libs.sls
+++ b/moj-docker-deploy/apps/libs.sls
@@ -34,6 +34,10 @@
       cname: {{container}}
       default_registry: {{ salt['pillar.get']('default_registry', '') }}
       tag: '{{ salt['grains.get']('%s_tag' % container , 'latest') | replace("'", "''") }}'
+      ec2_neighbours: {{ salt['grains.get']('ec2_neighbours', {}) }}
+      ec2_local_private_dns_name: {{ salt['grains.get']('ec2_local:private_dns_name', '') }}
+      ec2_local_private_dns_name_safe: {{ salt['grains.get']('ec2_local:private_dns_name_safe', '') }}
+      ec2_cluster_nodes_prefix: {{ cdata.get('cluster_nodes_prefix', '') }}
 
 {{container}}_service:
   service.running:

--- a/moj-docker-deploy/apps/libs.sls
+++ b/moj-docker-deploy/apps/libs.sls
@@ -34,10 +34,6 @@
       cname: {{container}}
       default_registry: {{ salt['pillar.get']('default_registry', '') }}
       tag: '{{ salt['grains.get']('%s_tag' % container , 'latest') | replace("'", "''") }}'
-      ec2_neighbours: {{ salt['grains.get']('ec2_neighbours', {}) }}
-      ec2_local_private_dns_name: {{ salt['grains.get']('ec2_local:private_dns_name', '') }}
-      ec2_local_private_dns_name_safe: {{ salt['grains.get']('ec2_local:private_dns_name_safe', '') }}
-      ec2_cluster_nodes_prefix: {{ cdata.get('cluster_nodes_prefix', '') }}
 
 {{container}}_service:
   service.running:

--- a/moj-docker-deploy/apps/templates/upstart_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_container.conf
@@ -23,7 +23,22 @@ script
                 ENV_OPTS="--env-file /etc/docker_env.d/{{cname}}"
         fi
 
-    docker run --name="{{ cname }}" {{cdata.get('docker_args', '')}} $ENV_OPTS $VOL_OPTS $PORT_OPTS {{container_full_name}}:"$TAG" {{cdata.get('startup_args', '')}}
+		# If clustering is enabled for this container, and we have neighbour hosts details are available
+		# then add the neighbour and container alias <container_name>.<remote_instance_dns_name> to
+		# the hosts file in the container
+		{% if 'enable_clustering' in cdata and cdata['enable_clustering'] == True %}
+		HOSTS_OPTS="{% for ip, neighbours in ec2_neighbours.items() %} --add-host={{neighbours['private_dns_name']}}:{{ip}} --add-host={{cname}}.{{neighbours['private_dns_name']}}:{{ip}}{% endfor %}"
+		HOSTS_OPTS_SAFE="{% for ip, neighbours in ec2_neighbours.items() %} --add-host={{neighbours['private_dns_name_safe']}}:{{ip}} --add-host={{cname}}-{{neighbours['private_dns_name_safe']}}:{{ip}}{% endfor %}"
+		CLUSTER_NODES="[ {% for ip, neighbours in ec2_neighbours.items() %} '{{ec2_cluster_nodes_prefix}}{{cname}}.{{neighbours['private_dns_name']}}'{% if not loop.last %},{% endif %} {% endfor %}]"
+		CLUSTER_NODES_SAFE="[{% for ip, neighbours in ec2_neighbours.items() %} '{{ec2_cluster_nodes_prefix}}{{cname}}-{{neighbours['private_dns_name_safe']}}'{% if not loop.last %},{% endif %} {% endfor %}]"
+		HOSTNAME_OPTS=" -h {{cname}}-{{ec2_local_private_dns_name_safe}} "
+		{% endif %}
+
+    docker run --name="{{ cname }}" {{cdata.get('docker_args', '')}} \
+    	-e "CLUSTER_NODES=${CLUSTER_NODES}" \
+    	-e "CLUSTER_NODES_SAFE=${CLUSTER_NODES_SAFE}" \
+    	${HOSTNAME_OPTS} ${HOSTS_OPTS} ${HOSTS_OPTS_SAFE} ${ENV_OPTS} ${VOL_OPTS} ${PORT_OPTS} {{container_full_name}}:"$TAG" {{cdata.get('startup_args', '')}}
+
 end script
 
 # Post start script checks that the container it actually running

--- a/moj-docker-deploy/apps/templates/upstart_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_container.conf
@@ -26,11 +26,15 @@ script
 		# If clustering is enabled for this container, and we have neighbour hosts details are available
 		# then add the neighbour and container alias <container_name>.<remote_instance_dns_name> to
 		# the hosts file in the container
+		{% set ec2_neighbours = salt['grains.get']('ec2_neighbours', {}) %}
+		{% set ec2_local_private_dns_name = salt['grains.get']('ec2_local:private_dns_name', '') %}
+		{% set ec2_local_private_dns_name_safe = salt['grains.get']('ec2_local:private_dns_name_safe', '') %}
+
 		{% if 'enable_clustering' in cdata and cdata['enable_clustering'] == True %}
 		HOSTS_OPTS="{% for ip, neighbours in ec2_neighbours.items() %} --add-host={{neighbours['private_dns_name']}}:{{ip}} --add-host={{cname}}.{{neighbours['private_dns_name']}}:{{ip}}{% endfor %}"
 		HOSTS_OPTS_SAFE="{% for ip, neighbours in ec2_neighbours.items() %} --add-host={{neighbours['private_dns_name_safe']}}:{{ip}} --add-host={{cname}}-{{neighbours['private_dns_name_safe']}}:{{ip}}{% endfor %}"
-		CLUSTER_NODES="[ {% for ip, neighbours in ec2_neighbours.items() %} '{{ec2_cluster_nodes_prefix}}{{cname}}.{{neighbours['private_dns_name']}}'{% if not loop.last %},{% endif %} {% endfor %}]"
-		CLUSTER_NODES_SAFE="[{% for ip, neighbours in ec2_neighbours.items() %} '{{ec2_cluster_nodes_prefix}}{{cname}}-{{neighbours['private_dns_name_safe']}}'{% if not loop.last %},{% endif %} {% endfor %}]"
+		CLUSTER_NODES="[ {% for ip, neighbours in ec2_neighbours.items() %} '{{cname}}.{{neighbours['private_dns_name']}}'{% if not loop.last %},{% endif %} {% endfor %}]"
+		CLUSTER_NODES_SAFE="[{% for ip, neighbours in ec2_neighbours.items() %} '{{cname}}-{{neighbours['private_dns_name_safe']}}'{% if not loop.last %},{% endif %} {% endfor %}]"
 		HOSTNAME_OPTS=" -h {{cname}}-{{ec2_local_private_dns_name_safe}} "
 		{% endif %}
 


### PR DESCRIPTION
To ease the implementation of clustering containers between different
EC2 hosts containers, this change adds in the aws-formula to expose
details about other EC2 hosts within the same VPC. Then uses this
information to setup defined dns resolvable names and environment
variables to these other hosts.
