### PR TITLE
Create toplevel include for moj-docker-deploy mods

### DIFF
--- a/moj-docker-deploy/init.sls
+++ b/moj-docker-deploy/init.sls
@@ -1,0 +1,4 @@
+include:
+ - .apps.branchrunner
+ - .apps.containers
+ - .deploy-user


### PR DESCRIPTION
With the current salt module layout, if you create a new module then you
also need to make a commit to the template-deploy repo.  This commit
creates a top-level init.sls file such that future changes to salt
modules can be included by changing just one repo (this one).

This functionality depends on a one-off change to template-delpoy, which will be raised as a PR to be merged after this one. 
