### PR TITLE
Tag attached EBS volumes

### DIFF
--- a/moj-docker-deploy/files/ebs-tag.py
+++ b/moj-docker-deploy/files/ebs-tag.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+
+import boto
+import sys
+import boto.ec2
+import requests
+
+conn = boto.ec2.connect_to_region('eu-west-1')
+my_instance_id = requests.get('http://169.254.169.254/latest/meta-data/instance-id').text
+my_volumes = [v for v in conn.get_all_volumes() if v.attach_data.instance_id == my_instance_id]
+
+def query(expected_tags):
+  for v in my_volumes:
+    for k in expected_tags.keys():
+      if not v.tags.has_key(k):
+        return False
+      if v.tags[k] != expected_tags[k]:
+        return False
+  return True
+
+def ensure(desired_tags):
+  try:
+    for v in my_volumes:
+      v.add_tags(desired_tags)
+  except boto.exception.EC2ResponseError:
+    print "Failed to set tags {}. Perhaps the permisson ec2:CreateTags is missing from the IAM user".format(desired_tags)
+    # Ideally we'd want to return a 1 here but this aborts the salt run. We don't want to
+    # do that to products which might still be on an old stack without that permission.
+    sys.exit(0)
+  if not query(desired_tags):
+    print "Failed to set tags {}".format(desired_tags)
+    sys.exit(1)
+
+if len(sys.argv) < 3:
+  sys.stderr.write("Usage: {} <query|ensure> <tag:value>...\n".format(sys.argv[0]))
+  sys.exit(99)
+
+tags = dict(map( lambda x: x.split(':'), sys.argv[2:]))
+
+if sys.argv[1] == 'query':
+  if query(tags):
+    sys.exit(0)
+  else:
+    sys.exit(1)
+
+elif sys.argv[1] == 'ensure':
+  ensure(tags)
+else:
+  sys.stderr.write("Usage: {} <query|ensure> <tag:value>...\n".format(sys.argv[0]))
+  sys.exit(99)

--- a/moj-docker-deploy/init.sls
+++ b/moj-docker-deploy/init.sls
@@ -2,3 +2,4 @@ include:
  - .apps.branchrunner
  - .apps.containers
  - .deploy-user
+ - .tag-ebs-volumes

--- a/moj-docker-deploy/tag-ebs-volumes.sls
+++ b/moj-docker-deploy/tag-ebs-volumes.sls
@@ -15,15 +15,8 @@ tag-ebs-volumes:
     - require:
       - file: /usr/local/bin/ebs-tag.py
 
-python-pip:
-  pkg.installed
-
 requests:
-  pip.installed:
-    - require:
-      - pkg: python-pip
+  pip.installed
 
 boto:
-  pip.installed:
-    - require:
-      - pkg: python-pip
+  pip.installed

--- a/moj-docker-deploy/tag-ebs-volumes.sls
+++ b/moj-docker-deploy/tag-ebs-volumes.sls
@@ -1,0 +1,29 @@
+tag-ebs-volumes:
+  file.managed:
+    - source: salt://moj-docker-deploy/files/ebs-tag.py
+    - name: /usr/local/bin/ebs-tag.py
+    - user: root
+    - group: root
+    - mode: '0755'
+    - require:
+      - pip: requests
+      - pip: boto
+  cmd.run:
+    - unless: /usr/local/bin/ebs-tag.py query Env:{{grains['Env']}} Apps:{{grains['Apps']}}
+    - name: /usr/local/bin/ebs-tag.py ensure Env:{{grains['Env']}} Apps:{{grains['Apps']}}
+    - cwd: /
+    - require:
+      - file: /usr/local/bin/ebs-tag.py
+
+python-pip:
+  pkg.installed
+
+requests:
+  pip.installed:
+    - require:
+      - pkg: python-pip
+
+boto:
+  pip.installed:
+    - require:
+      - pkg: python-pip


### PR DESCRIPTION
AutoScalingGroups tag EC2 instances but not volumes. Since salt will
highstate when a machine boots then we can do the tagging here.

In order to succeed, this operation requires the ec2:CreateTags perm
from the instance itself. In the event of this permission being missing
salt will continue, obliviously.

Useful though they are, tags are used only for auditing purposes. They
do not affect operation of a stack.

**NB This should only be merged after https://github.com/ministryofjustice/bootstrap-cfn/pull/153**

Assuming all are happy, once merged a new tagged release (v1.0.3) will need to be created of this repo.
