### PR TITLE
Add custom grains containing the redis elasticsearch endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
 
+* Add elasticache docker envs if available
 * Enable clustering of containers with containers in other EC2 instances
 * Fix macro calls introduced for nginx logs
 

--- a/formula-requirements.txt
+++ b/formula-requirements.txt
@@ -8,4 +8,4 @@ git@github.com:ministryofjustice/python-formula.git==v1.1.2
 git@github.com:ministryofjustice/hardening-formula.git==v1.2.2
 git@github.com:ministryofjustice/repos-formula.git==v1.1.1
 git@github.com:ministryofjustice/bootstrap-formula.git==v3.0.5
-git@github.com:ministryofjustice/aws-formula.git==v0.4.3
+git@github.com:ministryofjustice/aws-formula.git==v0.5.0

--- a/moj-docker-deploy/apps/templates/docker_env
+++ b/moj-docker-deploy/apps/templates/docker_env
@@ -19,6 +19,11 @@ DATABASE_URL={{ "%s://%s:%s@%s:%s/%s" | format(
               }}
 {% endif %}
 
+{%- if salt['grains.get']('ElasticacheReplicationGroupName', False) %}
+REDIS_HOST={{ salt['grains.get']('elasticache:default_endpoint:Address', default='') }}
+REDIS_PORT={{ salt['grains.get']('elasticache:default_endpoint:Port', default='') }}
+REDIS_URL={{ salt['grains.get']('ElasticacheEngine', default='') }}://{{ salt['grains.get']('elasticache:default_endpoint:Address', default='') }}:{{ salt['grains.get']('elasticache:default_endpoint:Port', default='') }}
+{% endif %}
 
 {%- if 'envvars' in appenv %}
 {% for k, v in appenv.envvars.items() %}

--- a/moj-docker-deploy/apps/templates/docker_env_bash
+++ b/moj-docker-deploy/apps/templates/docker_env_bash
@@ -18,6 +18,12 @@ DATABASE_URL='{{ "%s://%s:%s@%s:%s/%s" | format(
               }}'
 {% endif %}
 
+{%- if salt['grains.get']('ElasticacheReplicationGroupName', False) %}
+REDIS_HOST='{{ salt['grains.get']('elasticache:default_endpoint:Address', default='')  | replace("'", "'\\''") }}'
+REDIS_PORT='{{ salt['grains.get']('elasticache:default_endpoint:Port', default='')  | replace("'", "'\\''") }}'
+REDIS_URL='{{ salt['grains.get']('ElasticacheEngine', default='') }}://{{ salt['grains.get']('elasticache:default_endpoint:Address', default='')  | replace("'", "'\\''") }}:{{ salt['grains.get']('elasticache:default_endpoint:Port', default='')  | replace("'", "'\\''") }}'
+{% endif %}
+
 {%- if 'envvars' in appenv %}
 {% for k, v in appenv.envvars.items() %}
 {{ k }}='{{ v | replace("'", "'\\''") }}'


### PR DESCRIPTION
Sets grains for elasticache endpoints for a redis type. Consisting of
a primary (read-write) endpoint and a list of read-only endpoints.
These endpoints will only be collected if there is already a grain
ElasticacheReplicationGroupName containing the replication group
name.

The grain set has the form,

```
  'elasticache':  {
    'primary_endpoint': {'address': <address>, 'port': <port>},
    'default_endpoint': {'address': <address>, 'port': <port>},
    'read_endpoints': [
      {'address': <address>, 'port': <port>},
      {'address': <address>, 'port': <port>},
      {'address': <address>, 'port': <port>}
    ]
  }
```

Requires PR https://github.com/ministryofjustice/bootstrap-cfn/pull/152
And note issue: https://github.com/ministryofjustice/template-deploy/issues/171
