### PR TITLE
use grains from aws formula for elb name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* use grains from aws formula for elb name
+
 ## v1.0.2
 
 * Move _states to root directory

--- a/formula-requirements.txt
+++ b/formula-requirements.txt
@@ -8,3 +8,4 @@ git@github.com:ministryofjustice/python-formula.git==v1.1.2
 git@github.com:ministryofjustice/hardening-formula.git==v1.2.2
 git@github.com:ministryofjustice/repos-formula.git==v1.1.1
 git@github.com:ministryofjustice/bootstrap-formula.git==v3.0.5
+git@github.com:ministryofjustice/aws-formula.git==v0.4.0

--- a/metadata.yml
+++ b/metadata.yml
@@ -5,4 +5,5 @@ dependencies:
   - git@github.com:ministryofjustice/admins-formula.git
   - git@github.com:ministryofjustice/hardening-formula.git
   - git@github.com:ministryofjustice/bootstrap-formula.git>=v3.0.3
+  - git@github.com:ministryofjustice/aws-formula.git>=v0.4.0
 

--- a/moj-docker-deploy/apps/libs.sls
+++ b/moj-docker-deploy/apps/libs.sls
@@ -57,10 +57,10 @@
 {% macro setup_elb_registering(container) %}
 
 {% if salt['grains.get']('zero_downtime_deploy', False) %}
-{% for elb in salt['pillar.get']('elb',[]) %}
-{{ container }}_{{ elb['name'] }}_down:
+{% for lb in salt['grains.get']('lbs',{}).keys() %}
+{{ container }}_{{ lb }}_down:
   elb_reg.instance_deregistered:
-    - name: ELB-{{ elb['name'] | replace(".", "") }}
+    - name: {{ lb }}
     - instance: {{ salt['grains.get']('aws_instance_id', []) }}
     - timeout: 130
     # This must always happen before we touch the service:
@@ -76,9 +76,9 @@
       - file: /etc/docker_env.d/{{container}}
       - docker: {{container}}_pull
 
-{{ container }}_{{ elb['name'] }}_up:
+{{ container }}_{{ lb }}_up:
   elb_reg.instance_registered:
-    - name: ELB-{{ elb['name'] | replace(".", "") }}
+    - name: {{ lb }}
     - instance: {{ salt['grains.get']('aws_instance_id', []) }}
     - timeout: 120
     - watch:


### PR DESCRIPTION
Since many of the aws names are now autogenerated we need a way to know which elb to deregister/register. With this change the name is taken from the grains. The key name for the lbs grain is
the (short) name of the load balancer.

This depends on https://github.com/ministryofjustice/moj-docker-deploy-formula/pull/3 , as that is where we first import the aws-formula repo in metadata.yaml

This will depend on the feature release of https://github.com/ministryofjustice/aws-formula/pull/2

More background info on why this is needed can be found at https://github.com/ministryofjustice/aws-formula/pull/2
