### PR TITLE
Set a default nginx host to avoid branch confusion

### DIFF
--- a/moj-docker-deploy/apps/templates/nginx_container.conf
+++ b/moj-docker-deploy/apps/templates/nginx_container.conf
@@ -6,7 +6,11 @@ upstream {{ container }} { server 127.0.0.1:{{ salt['docker.port'](container, co
 {% endfor %}
 
 server {
-    listen     {{ appdata.get('nginx_port', 80) }} ;
+    {% if appdata.get('branchbuilder', False) %}
+    listen     {{ appdata.get('nginx_port', 80) }};
+    {% else %}
+    listen     {{ appdata.get('nginx_port', 80) }} default_server;
+    {% endif %}
     server_name {{ server_name }} {{ appdata.get('server_names',[])|join(' ') }}; 
 
     client_max_body_size {{ appdata.get('client_max_body_size', '3m') }};


### PR DESCRIPTION
When using branchrunners, nginx treats the first defined `server` (so usually the first file in `/etc/nginx/conf.d/`) listening to a given port as the default host if no `server_name` match is found. This means that a branch called `aaa` (or anything alphabetically before the `server_name`) might override the main app host.

Instead, we want the default host to be explicitly set to a non-branchbuilder host.
