### PR TITLE
Fix macro import for cleanup containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Fix macro import for cleanup containers
+
 ## v1.0.5
 
 * Set a default nginx host to avoid branch confusion

--- a/moj-docker-deploy/apps/container-cleanup.sls
+++ b/moj-docker-deploy/apps/container-cleanup.sls
@@ -1,7 +1,7 @@
 include:
   - docker
 
-{% import 'apps/libs.sls' as macros with context %}
+{% import 'moj-docker-deploy/apps/libs.sls' as macros with context %}
 
 {{ macros.create_container_config('tutum_cleanup', {
   'name': 'tutum/cleanup',


### PR DESCRIPTION
This import assumed that the apps/lib.sls was in the current formula,
but chances are that's not the case anymore.
