### PR TITLE
Add a fallback check to the pillar for a containers host port

### DIFF
--- a/moj-docker-deploy/apps/templates/nginx_container.conf
+++ b/moj-docker-deploy/apps/templates/nginx_container.conf
@@ -2,7 +2,13 @@
 
 {% for container, cdata in appdata.get('containers', {}).items() %}
 {% set container_port = cdata.get('ports')['app']['container'] %}
-upstream {{ container }} { server 127.0.0.1:{{ salt['docker.port'](container, container_port)['out'][0]['HostPort'] }}; }
+
+{% if salt['docker.port'](container, container_port)['out'] %}
+{% set host_port = salt['docker.port'](container, container_port)['out'][0]['HostPort'] %}
+{% else %}
+{% set host_port = cdata.get('ports')['app']['host'] %}
+{% endif %}
+upstream {{ container }} { server 127.0.0.1:{{ host_port }}; }
 {% endfor %}
 
 server {


### PR DESCRIPTION
Currently we use the docker.port call for salt to get a containers
actual exposed host port. When we have called --net="host" with
docker though, this will be empty, and the call will fail, even
though the containers port is still exposed in the instance. This
change will add a fallback call to the pillar, so that we can catch
this situation and try our best to get the host port if possible.
