### PR TITLE
Fix macro calls introduced for nginx logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+* Fix macro calls introduced for nginx logs
+
 ## v1.0.6
 
 * Fix macro import for cleanup containers

--- a/moj-docker-deploy/apps/templates/nginx_container.conf
+++ b/moj-docker-deploy/apps/templates/nginx_container.conf
@@ -22,7 +22,7 @@ server {
 
 
     {% if appdata.get('nginx_logs', False) %}
-        {% nginx_macros.nginx_custom_log_formats_and_files(appdata.get('nginx_logs')) %}
+        {{ nginx_macros.nginx_custom_log_formats_and_files(appdata.get('nginx_logs')) }}
     {% else %}
         access_log  /var/log/nginx/{{server_name}}.access.json  logstash_json;
         error_log  /var/log/nginx/{{server_name}}.error.log error;


### PR DESCRIPTION
Macro call is using the wrong syntax
