### PR TITLE
Strip dots from branch name subdomain host name

### DIFF
--- a/moj-docker-deploy/apps/branchrunner.sls
+++ b/moj-docker-deploy/apps/branchrunner.sls
@@ -80,7 +80,7 @@ include:
     - mode: 644
     - template: jinja
     - context:
-      server_name: '{{branch_name}}.{{
+      server_name: '{{branch_name | replace(".", "-") }}.{{
         salt['pillar.get'](
           'branch_runner:container_base_hostname',
           default=salt['pillar.get']('master_zone')


### PR DESCRIPTION
If the branch name passed to the branchrunner contains dots these
will be added to the vhost construction of the domain name, leading
to accidental additional nesting of the domain name. This change
will strip the dots from the branch name before using it.
