### PR TITLE
Update nginx version to 3.3.1

### DIFF
--- a/formula-requirements.txt
+++ b/formula-requirements.txt
@@ -1,4 +1,4 @@
-git@github.com:ministryofjustice/nginx-formula.git==v3.3.0
+git@github.com:ministryofjustice/nginx-formula.git==v3.3.1
 git@github.com:ministryofjustice/apparmor-formula.git==v1.0.1
 git@github.com:ministryofjustice/firewall-formula.git==v2.0.0
 git@github.com:ministryofjustice/docker-formula.git==v1.4.0

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,6 +1,6 @@
 dependencies:
   - git@github.com:ministryofjustice/docker-formula.git
-  - git@github.com:ministryofjustice/nginx-formula.git
+  - git@github.com:ministryofjustice/nginx-formula.git>=v3.3.1
   - git@github.com:ministryofjustice/repos-formula.git
   - git@github.com:ministryofjustice/admins-formula.git
   - git@github.com:ministryofjustice/hardening-formula.git


### PR DESCRIPTION
The 3.3.0 version of nginx-formula was broken, this will target the
fixed version.
