### PR TITLE
Add an initial_version option to the container pillar

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ For more help in resolving problems and errors, see the [Template Deploy Trouble
 ####[Proxied Containers Settings Subsection](#proxied-containers-settings-subsection)
 - [containers](#containers)
 - [name](#name)
+- [initial_version](#initial_version)
 - [registry](#registry)
 - [http_locations](#http_locations)
 - [location](#location)
@@ -178,6 +179,14 @@ This is the name of the container as it is tagged in docker
 
 ```yaml        
             name: tutum/hello-world
+```
+
+####initial_version
+This is the initial version tag of the container to install if there is no other version
+already installed on the intance.
+
+```yaml        
+            initial_version: master.kj2312km
 ```
 
 ####registry

--- a/moj-docker-deploy/apps/libs.sls
+++ b/moj-docker-deploy/apps/libs.sls
@@ -33,7 +33,8 @@
       cdata: {{cdata | yaml}}
       cname: {{container}}
       default_registry: {{ salt['pillar.get']('default_registry', '') }}
-      tag: '{{ salt['grains.get']('%s_tag' % container , 'latest') | replace("'", "''") }}'
+      {% set default_version = cdata.get('initial_version', 'latest') %}
+      tag: '{{ salt['grains.get']('%s_tag' % container , default_version) | replace("'", "''") }}'
 
 {{container}}_service:
   service.running:


### PR DESCRIPTION
At the moment we default to latest when a container version has not been
deployed on an instance. This change will allow us to set a default
initial_version of the container in the pillar to use instead of
defaulting to 'latest'
