### PR TITLE
Remove require on requests

### DIFF
--- a/moj-docker-deploy/tag-ebs-volumes.sls
+++ b/moj-docker-deploy/tag-ebs-volumes.sls
@@ -15,8 +15,5 @@ tag-ebs-volumes:
     - require:
       - file: /usr/local/bin/ebs-tag.py
 
-requests:
-  pip.installed
-
 boto:
   pip.installed


### PR DESCRIPTION
The requests python module is supplied by the python formula,
requiring it here again breaks salt.
