### PR TITLE
upped nginx-formula version to 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased 
+
+Features:
+* Update nginx version to 3.3.2
+
 ## v1.3.1
 
 Fixes:

--- a/formula-requirements.txt
+++ b/formula-requirements.txt
@@ -1,4 +1,4 @@
-git@github.com:ministryofjustice/nginx-formula.git==v3.3.1
+git@github.com:ministryofjustice/nginx-formula.git==v3.3.2
 git@github.com:ministryofjustice/apparmor-formula.git==v1.0.1
 git@github.com:ministryofjustice/firewall-formula.git==v2.0.0
 git@github.com:ministryofjustice/docker-formula.git==v1.4.0


### PR DESCRIPTION
to include fix for "too many items to unpack" error when defining a custom nginx log format
