### PR TITLE
Fixes docker pulling latest tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.3.5
+Fixes:
+* docker pulling the wrong tag 
+
 ## v1.3.4
 
 * Add elasticache docker envs if available

--- a/moj-docker-deploy/apps/libs.sls
+++ b/moj-docker-deploy/apps/libs.sls
@@ -11,11 +11,12 @@
 {% set default_registry = salt['pillar.get']('default_registry', '') %}
 {% set docker_registry =  cdata.get('registry', default_registry) %}
 {% set container_full_name = (docker_registry, container_name) | select | join("/") %}
+{% set default_version = cdata.get('initial_version', 'latest') %}
 
 {{ container }}_pull:
   docker.pulled:
     - name: {{ container_full_name }}
-    - tag: '{{ salt['grains.get']('%s_tag' % container , 'latest') | replace("'", "''") }}'
+    - tag: '{{ salt['grains.get']('%s_tag' % container , default_version) | replace("'", "''") }}'
     - force: True
     - require:
       # We need this for docker-py to find the dockercfg and login
@@ -33,7 +34,6 @@
       cdata: {{cdata | yaml}}
       cname: {{container}}
       default_registry: {{ salt['pillar.get']('default_registry', '') }}
-      {% set default_version = cdata.get('initial_version', 'latest') %}
       tag: '{{ salt['grains.get']('%s_tag' % container , default_version) | replace("'", "''") }}'
 
 {{container}}_service:


### PR DESCRIPTION
Currently docker first pulls latest tag regardless of initial_version
setting, and the correct tag is only pulled after a service start.
What this means is that lets say tag:latest image is 1 mb and
initial_version image is 800mb, it will only download the 800mb
image during "docker run" .. which is bad.
