### PR TITLE
Updated nginx-formula dependency to v3.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.3.6
+
+Features:
+* Updated nginx-formula dependency to v3.3.4
+
+Fixes:
+* custom nginx json log formats resulting in unparseable double-quoted json
+
 ## v1.3.5
 Fixes:
 * docker pulling the wrong tag 

--- a/formula-requirements.txt
+++ b/formula-requirements.txt
@@ -1,4 +1,4 @@
-git@github.com:ministryofjustice/nginx-formula.git==v3.3.3
+git@github.com:ministryofjustice/nginx-formula.git==v3.3.4
 git@github.com:ministryofjustice/apparmor-formula.git==v1.0.1
 git@github.com:ministryofjustice/firewall-formula.git==v2.0.0
 git@github.com:ministryofjustice/docker-formula.git==v1.4.0


### PR DESCRIPTION
Fixes an issue with custom nginx json log formats resulting in unparseable double-quoted json when shipped to logstash via beaver
