### PR TITLE
Allow disabling the default server setting on a vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ This is the port you should direct your ELB to. If not specified, the default se
 ```yaml    
     nginx_port: 80
 ```
+
+You can specify multiple vhosts with the same port, but in that case you have to make sure that all the vhosts that will not be the default server also explicitly say so as below. If not, nginx will refuse to load the config due to multiple default servers being set.
+
+```yaml
+    default_server: False
+```
+
     
 ###nginx_logs
 This key allows you to customise the format & path of nginx logs. If not specified, the default logging configuration will be used, resulting in these lines in the nginx config file:

--- a/moj-docker-deploy/apps/templates/nginx_container.conf
+++ b/moj-docker-deploy/apps/templates/nginx_container.conf
@@ -13,7 +13,7 @@ upstream {{ container }} { server 127.0.0.1:{{ host_port }}; }
 {% endfor %}
 
 server {
-    {% if appdata.get('branchbuilder', False) %}
+    {% if appdata.get('branchbuilder', False) or appdata.get('default_server', True) == False %}
     listen     {{ appdata.get('nginx_port', 80) }};
     {% else %}
     listen     {{ appdata.get('nginx_port', 80) }} default_server;


### PR DESCRIPTION
If we have multiple vhosts with the same nginx_port set, they will
all be set with listen: <port> default server, causing nginx to refuse
to load the config since there are multiple default servers. This change
allows us to explicitly disable the default server setting on individual
vhosts.
