### PR TITLE
Allow overriding database settings in the pillar

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,14 +258,20 @@ These environment variables will be set in the container, these will often be a 
 ```
 		          
 Note you get some free variables for database details etc, the following will be set in the container automatically.
+The automatic values below cannot be overridden
 
 - *ENV*: The environment you specify in the fab command
 - *PROJECT*: The application name you specify in the fab command
+- *DATABASE_URL*: The RDS database url, in the form DB_ENGINE://DB_USERNAME:DB_PASSWORD@DB_HOST:DB_PORT/DB_NAME
+
+The following automatic values can be overriden in the pillar 
+
+- *DB_ENGINE*: The RDS engine
 - *DB_HOST*: The RDS hostname
 - *DB_PORT*: The RDS port
 - *DB_USERNAME*: The RDS username set in the cloudformation yaml
 - *DB_PASSWORD*: The RDS password set in the cloudformation yaml
-- *DATABASE_URL*: db-engine://db-user:db-password@db-host:db-port/db-name
+
 
 #### enable\_clustering
 

--- a/moj-docker-deploy/apps/templates/docker_env
+++ b/moj-docker-deploy/apps/templates/docker_env
@@ -1,32 +1,37 @@
-PROJECT={{ salt['grains.get']('Apps', default='unknown') }}
-ENV={{ salt['grains.get']('Env', default='unknown') }}
-DOCKER_STATE={{ task }}
+{%- set envvars = appenv.get('envvars', {}) %}
 
+# Setup database using RDS if it exits
 
 {%- if salt['pillar.get']('rds:db-engine', False) %}
-DB_HOST={{ salt['grains.get']('dbhost', default='unknown') }}
-DB_PORT={{ salt['grains.get']('dbport', default='unknown') }}
-DB_USERNAME={{ salt['pillar.get']("rds:db-master-username","") }}
-DB_PASSWORD={{ salt['pillar.get']("rds:db-master-password","") }}
-{% set db_password = pillar['rds']['db-master-password'] | urlencode %}
-DATABASE_URL={{ "%s://%s:%s@%s:%s/%s" | format(
-                        pillar['rds']['db-engine'],
-                        pillar['rds']['db-master-username'],
-                        db_password,
-                        grains['dbhost'],
-                        grains['dbport'],
-                        pillar['rds']['db-name'])
-              }}
+{% set db_engine = envvars.get('DB_ENGINE', salt['pillar.get']('rds:db-engine', "")) | urlencode %}
+{% set db_host = envvars.get('DB_HOST', salt['grains.get']('dbhost', default='unknown')) | urlencode %}
+{% set db_port = envvars.get('DB_PORT', salt['grains.get']('dbport', default='unknown')) | urlencode %}
+{% set db_name = envvars.get('DB_NAME', salt['pillar.get']('rds:db-name', "")) | urlencode %}
+{% set db_username = envvars.get('DB_USERNAME', salt['pillar.get']("rds:db-master-username","")) | urlencode %}
+{% set db_password = envvars.get('DB_PASSWORD', salt['pillar.get']("rds:db-master-password","")) | urlencode %}
+DB_ENGINE={{ db_engine }}
+DB_HOST={{ db_host }}
+DB_PORT={{ db_port }}
+DB_NAME={{db_name}}
+DB_USERNAME={{ db_username }}
+DB_PASSWORD={{ db_password }}
+DATABASE_URL={{db_engine}}://{{db_username}}:{{db_password}}@{{db_host}}:{{db_port}}/{{db_name}}
 {% endif %}
 
+# Setup redis using elasticache if it exists
 {%- if salt['grains.get']('ElasticacheReplicationGroupName', False) %}
 REDIS_HOST={{ salt['grains.get']('elasticache:default_endpoint:Address', default='') }}
 REDIS_PORT={{ salt['grains.get']('elasticache:default_endpoint:Port', default='') }}
 REDIS_URL={{ salt['grains.get']('ElasticacheEngine', default='') }}://{{ salt['grains.get']('elasticache:default_endpoint:Address', default='') }}:{{ salt['grains.get']('elasticache:default_endpoint:Port', default='') }}
 {% endif %}
 
-{%- if 'envvars' in appenv %}
-{% for k, v in appenv.envvars.items() %}
+# Load in container environment variables
+# Note these will override the ones above
+{% for k, v in envvars.items() %}
 {{ k }}={{ v }}
 {% endfor %}
-{% endif %}
+
+# These variables should are not overriden by the pillar
+PROJECT={{ salt['grains.get']('Apps', default='unknown') }}
+ENV={{ salt['grains.get']('Env', default='unknown') }}
+DOCKER_STATE={{ task }}

--- a/moj-docker-deploy/apps/templates/docker_env_bash
+++ b/moj-docker-deploy/apps/templates/docker_env_bash
@@ -1,31 +1,36 @@
-PROJECT='{{ salt['grains.get']('Apps', default='unknown') | replace("'", "'\\''") }}'
-ENV='{{ salt['grains.get']('Env', default='unknown') | replace("'", "'\\''") }}'
-DOCKER_STATE='{{ task | replace("'", "'\\''") }}'
+{%- set envvars = appenv.get('envvars', {}) %}
 
+# Setup database using RDS if it exits
 {%- if salt['pillar.get']('rds:db-engine', False) %}
-DB_HOST='{{ salt['grains.get']('dbhost', default='unknown') | replace("'", "'\\''") }}'
-DB_PORT='{{ salt['grains.get']('dbport', default='unknown') | replace("'", "'\\''") }}'
-DB_USERNAME='{{ salt['pillar.get']("rds:db-master-username","") | replace("'", "'\\''") }}'
-DB_PASSWORD='{{ salt['pillar.get']("rds:db-master-password","") | replace("'", "'\\''") }}'
-{% set db_password = pillar['rds']['db-master-password'] | urlencode %}
-DATABASE_URL='{{ "%s://%s:%s@%s:%s/%s" | format(
-                        pillar['rds']['db-engine'],
-                        pillar['rds']['db-master-username'],
-                        db_password,
-                        grains['dbhost'],
-                        grains['dbport'],
-                        pillar['rds']['db-name']) | replace("'", "'\\''")
-              }}'
+{% set db_engine = envvars.get('DB_ENGINE', salt['pillar.get']('rds:db-engine', "")) | urlencode %}
+{% set db_host = envvars.get('DB_HOST', salt['grains.get']('dbhost', default='unknown')) | urlencode %}
+{% set db_port = envvars.get('DB_PORT', salt['grains.get']('dbport', default='unknown')) | urlencode %}
+{% set db_name = envvars.get('DB_NAME', salt['pillar.get']('rds:db-name', "")) | urlencode %}
+{% set db_username = envvars.get('DB_USERNAME', salt['pillar.get']("rds:db-master-username","")) | urlencode %}
+{% set db_password = envvars.get('DB_PASSWORD', salt['pillar.get']("rds:db-master-password","")) | urlencode %}
+DB_ENGINE='{{ db_engine | replace("'", "'\\''") }}'
+DB_HOST='{{ db_host | replace("'", "'\\''") }}'
+DB_PORT='{{ db_port | replace("'", "'\\''") }}'
+DB_NAME='{{ db_name | replace("'", "'\\''") }}'
+DB_USERNAME='{{ db_username | replace("'", "'\\''") }}'
+DB_PASSWORD='{{ db_password | replace("'", "'\\''") }}'
+DATABASE_URL='{{db_engine}}://{{db_username}}:{{db_password}}@{{db_host}}:{{db_port}}/{{db_name}}'
 {% endif %}
 
+# Setup redis using elasticache if it exists
 {%- if salt['grains.get']('ElasticacheReplicationGroupName', False) %}
 REDIS_HOST='{{ salt['grains.get']('elasticache:default_endpoint:Address', default='')  | replace("'", "'\\''") }}'
 REDIS_PORT='{{ salt['grains.get']('elasticache:default_endpoint:Port', default='')  | replace("'", "'\\''") }}'
 REDIS_URL='{{ salt['grains.get']('ElasticacheEngine', default='') }}://{{ salt['grains.get']('elasticache:default_endpoint:Address', default='')  | replace("'", "'\\''") }}:{{ salt['grains.get']('elasticache:default_endpoint:Port', default='')  | replace("'", "'\\''") }}'
 {% endif %}
 
-{%- if 'envvars' in appenv %}
-{% for k, v in appenv.envvars.items() %}
+# Load in container environment variables
+# Note these will override the ones above
+{% for k, v in envvars.items() %}
 {{ k }}='{{ v | replace("'", "'\\''") }}'
 {% endfor %}
-{% endif %}
+
+# These variables should are not overriden by the pillar
+PROJECT='{{ salt['grains.get']('Apps', default='unknown') | replace("'", "'\\''") }}'
+ENV='{{ salt['grains.get']('Env', default='unknown') | replace("'", "'\\''") }}'
+DOCKER_STATE='{{ task | replace("'", "'\\''") }}'


### PR DESCRIPTION
Currently we generate the DATABASE_URL from the pillar and grains,
this change makes sure that all the environment variables generated
in the pillar will reflect any overrides set in the pillar.

The motivation is as follows, 

DATABASE_URL is constructed from the cloudformation which means only one database is possible
For example, if 
- DATABASE_URL points to db1 since thats the one defined in the cloudformation
- We have 2 containers, both containers get a DATABASE_URL that points to db1.
- By constructing the URL _after_ getting pillar data, we can allow containers to override DB settings if it makes sense to, say , giving the second container a db url to a database 'db2'
