### PR TITLE
Add basic_authentication support in nginx proxy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For more help in resolving problems and errors, see the [Template Deploy Trouble
 - [docker_envs](#docker_envs)
 - [nginx_port](#nginx_port)
 - [nginx_logs](#nginx_logs)
+- [basic_auth](#basic_auth)
 - [assets_location](#assets_location)
 - [ssl](#ssl)
 - [proxies](#proxies)
@@ -139,6 +140,24 @@ If you want to customize this, you can specify additional (or replacement) forma
         - path: '/var/log/nginx/error.log'
           format: error
 ```
+
+
+###basic_auth
+This key specifies whether basic authentication will be used. If enabled and set to True the required nginx directives are added in the default (location)(#location) specified (or on the default / otherwise)
+```yaml
+	basic_auth: True
+```
+
+In order to provide credentials, one has to specify them in the basic_auth_creds pillar on the same level. Supplied passwords be in hash form as supplied by the htpasswd utility. For more information please visit (ngx_http_auth_basic_module)[http://nginx.org/en/docs/http/ngx_http_auth_basic_module.html]
+
+```yaml
+        docker_envs:
+          example.service.me:
+              basic_auth_creds:
+                  username1: 'HASH'
+                  username2: 'HASH'
+```
+
 
 ###assets_location
 This key specifies the location in nginx to proxy to the S3 bucket. If not specified, the default setting is as shown below.

--- a/moj-docker-deploy/apps/proxied-containers.sls
+++ b/moj-docker-deploy/apps/proxied-containers.sls
@@ -1,4 +1,4 @@
-# Setup template for proxied containers. 
+# Setup template for proxied containers.
 #
 # Containers will be configured to be created and service
 # jobs setup for them. Nginx will then be set up to proxy
@@ -25,6 +25,26 @@ include:
       appdata: {{appdata | yaml}}
     - watch_in:
       - service: nginx
+
+{% if appdata.get('basic_auth', False) %}
+/etc/nginx/conf.d/{{server_name}}.htpasswd
+  file.managed:
+    - source: salt//moj-docker-deploy/apps/templates/nginx_container.htpasswd
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - context:
+      server_name: {{server_name}}
+      appdata: {{appdata | yaml}}
+    - watch_in:
+      - service: nginx
+{% else %}
+/etc/nginx/conf.d/{{server_name}}.htpasswd
+  file.absent:
+    - watch_in:
+      - service: nginx
+{% endif %}
 
 # Create container configs for all the proxied containers
 {% for container, cdata in appdata.get('containers',{}).items() %} # Start container loop

--- a/moj-docker-deploy/apps/templates/nginx_container.conf
+++ b/moj-docker-deploy/apps/templates/nginx_container.conf
@@ -21,6 +21,7 @@ server {
     server_name {{ server_name }} {{ appdata.get('server_names',[])|join(' ') }}; 
 
     client_max_body_size {{ appdata.get('client_max_body_size', '3m') }};
+
     rewrite_log  on;
     {% for rewrite in appdata.get('rewrites', []) %}
     rewrite {{ rewrite.pattern }} {{ rewrite.to }} {{ rewrite.type }};
@@ -47,6 +48,11 @@ server {
         }
         add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
         {% endif %}
+
+	{% if cdata.get('basic_auth', False) %}
+	    auth_basic              "Restricted";
+	    auth_basic_user_file    /etc/nginx/conf.d/{{ server_name }}.htpasswd;
+	{% endif %}
 
         # we are not adding any new headers here as they will be set by load balancer
         proxy_redirect     off;

--- a/moj-docker-deploy/apps/templates/nginx_container.htpasswd
+++ b/moj-docker-deploy/apps/templates/nginx_container.htpasswd
@@ -1,0 +1,3 @@
+{% for user, password in appdata.get('basic_auth_creds', []) %}
+{{ user }}:{{ password }}
+{% endfor -%}


### PR DESCRIPTION
- Basic authentication support
- Credentials should be supplied in relevant pillar (passwords already
  hashed)
- Add a tunable for chunked transfer encoding (default off)
