### PR TITLE
[WIP] Set host header on ping.json for Django

### DIFF
--- a/moj-docker-deploy/apps/templates/nginx_container.conf
+++ b/moj-docker-deploy/apps/templates/nginx_container.conf
@@ -76,7 +76,14 @@ server {
         proxy_set_header   X-Real-IP         $HTTP_X_REAL_IP;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Proto $HTTP_X_FORWARDED_PROTO;
+        {#- If Django app uses DJANGO_ALLOWED_HOSTS env var set host header to server name #}
+        {#- this prevents Django from returning a 400 to the ELB healthchecker #}
+        {% if location == '/ping.json' and cdata.get('envvars')['DJANGO_ALLOWED_HOSTS'] is defined -%}
+        proxy_set_header   Host              {{ server_name }};
+        {#- In all other cases pass through the host header unchanged #}
+        {% else -%}
         proxy_set_header   Host              $host;
+        {%- endif %}
         proxy_pass http://{{container}};
     }
     {% endfor %}


### PR DESCRIPTION
This is to prevent Django returning a 400 when the host header doesn't
match the DJANGO_ALLOWED_HOSTS environment variable, which will be the
case for ELB healthcheck requests
