### PR TITLE
Allow container linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ For more help in resolving problems and errors, see the [Template Deploy Trouble
 - [location](#location)
 - [ports](#ports)
 - [volumes](#volumes)
+- [links_restarts](#links_restarts)
+- [links](#links)
 - [envvars](#envvars)
 - [enable_clustering](#enable_clustering)
 - [cluster_nodes_prefix](#cluster_nodes_prefix)
@@ -267,11 +269,24 @@ Here we can set the 'host' port, the port which docker forwards into the contain
 ####volumes
 This allows you to mount host volumes in the container.
 
-```yaml        
+```yaml
 	        volumes:
 	          es_vol:
 	            host: /mnt/es_data
 	            container: /data
+```
+
+
+####links_restarts
+If set to True, the init service jobs are set up to restart and re-link if the linked-to containers restart.
+
+####links
+This allows the container to be linked to other containers. The first entry in each key is the external container name, the second is the internal name for the container.
+
+```yaml
+          links:
+	          redis: redis1
+	          hello-external: hello-internal
 ```
 
 ####envvars

--- a/moj-docker-deploy/apps/templates/upstart_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_container.conf
@@ -1,7 +1,14 @@
 description "{{cname}} container"
 author "tools@digital.justice.gov.uk"
+
+{% if 'links' in cdata and cdata.get('links_restarts', False) %}
+start on ({% for linked_container_external, linked_container_internal in cdata.get('links').iteritems() %}{% if loop.index > 1 %} or{% endif %} started {{ linked_container_external }}_container{% endfor %})
+stop on runlevel [!2345] or ({% for linked_container_external, linked_container_internal in cdata.get('links').iteritems() %}{% if loop.index > 1 %} or{% endif %} stopped {{ linked_container_external }}_container{% endfor %})
+{% else %}
 start on filesystem and started docker
 stop on runlevel [!2345]
+{% endif %}
+
 respawn
 respawn limit 5 300
 env HOME=/root
@@ -38,11 +45,42 @@ script
 		HOSTNAME_OPTS=" -h {{cname}}-{{ec2_local_private_dns_name_safe}} "
 		{% endif %}
 
+		{% if 'links' in cdata %}
+		LINK_CONTAINERS="{% for linked_container_external, linked_container_internal in cdata.get('links').iteritems() %} --link {{ linked_container_external }}:{{ linked_container_internal }} {% endfor %} "
+		{% endif %}
+
     docker run --name="{{ cname }}" {{cdata.get('docker_args', '')}} \
+    	${LINK_CONTAINERS} \
     	-e "CLUSTER_NODES=${CLUSTER_NODES}" \
     	-e "CLUSTER_NODES_SAFE=${CLUSTER_NODES_SAFE}" \
     	${HOSTNAME_OPTS} ${HOSTS_OPTS} ${HOSTS_OPTS_SAFE} ${ENV_OPTS} ${VOL_OPTS} ${PORT_OPTS} {{container_full_name}}:"$TAG" {{cdata.get('startup_args', '')}}
 
+end script
+
+# Pre start check makes sure that we retry a few times to allow any linked containers to 
+# come up before starting, so that we can link to them successfully
+pre-start script
+				{% if 'links' in cdata %}
+				max_retry=5
+        echo INFO: Checking if containers required for linking are running...
+{% for linked_container_external, linked_container_internal in cdata.get('links').iteritems() %}
+				for i in $(seq 1 ${max_retry})
+        do
+          found_container=$(docker inspect --format='{% raw %}{{.Name}}{% endraw %}' {{ linked_container_external }} ) || $(echo "")
+          if [ "${found_container}" = "/{{ linked_container_external }}" ]; then
+          	echo INFO: Found container required for linking ${found_container}...
+          	break
+          elif [ "${i}" = "${max_retry}" ]; then
+          	echo CRITICAL: Retry timed out on container required for linking, {{ linked_container_external }}, exiting...
+          	exit 1
+          else
+          	echo WARNING: Could not find container required for linking, {{ linked_container_external }}, retry ${i}/${max_retry}...
+          	sleep 3
+          fi
+        done
+{% endfor %}
+{% endif%}
+     
 end script
 
 # Post start script checks that the container it actually running
@@ -51,7 +89,8 @@ end script
 post-start script
     echo INFO: Checking if container {{cname}} is running
 	# Test for success
-	for i in 1 2 3 4 5
+	max_retry=5
+	for i in $(seq 1 ${max_retry})
 	do
 		RUNNING_ID="`docker ps -q --filter name={{cname}}`"
 		if [ -z ${RUNNING_ID} ]; then


### PR DESCRIPTION
Allow container linking

Manually passing linking options to docker as args in the pillar will
set up linked containers sometimes. But since containers need to be up
before they are linked to, this requires a start order to run containers
in. Since we use upstart jobs, we can enable linking in the pillar and
alter the jobs to take this order into account, requiring the necessary
linked to containers to be running before the service will successfully
start, and reacting to those services restarting to restart and therefore
recover linking to the restarted container.
- Add links pillar option
- Automatically setup upstart start stanza to rely on linked container jobs
- Set upstart container job to link to containers specified in pillar
- Create pre-start upstart section to handle dependent job status
- Alter post-start script to use variable for max-retries for loop
