### PR TITLE
add arbitrary headers

### DIFF
--- a/moj-docker-deploy/apps/templates/nginx_container.conf
+++ b/moj-docker-deploy/apps/templates/nginx_container.conf
@@ -53,6 +53,9 @@ server {
 	    auth_basic              "Restricted";
 	    auth_basic_user_file    /etc/nginx/conf.d/{{ server_name }}.{{ container }}.htpasswd;
 	{% endif %}
+        {% for header, value in cdata.get('extra_headers', {}).items() %}
+            add_header {{header}} {{value}};
+        {% endfor %}
 
         # we are not adding any new headers here as they will be set by load balancer
         proxy_redirect     off;


### PR DESCRIPTION
a hash of extra_headers can optionally exist in an app container to allow the settings of additional HTTP headers in the response for the / location.
