### PR TITLE
Change container linking pillar structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,8 +278,9 @@ This allows you to mount host volumes in the container.
 
 ####links
 This is a list of container linking entries that allows the container to be linked to other containers.
-Each entry contains a required 'link' key with the container to link to as a value. By default, the linking container will start and stop in reaction to its target linked containers statuses. 
-This behaviour can be changed by supplying the 'required' key, with the value 'False'. This means that we are defining the target container link as non-essential to the running of the linking container.
+Each entry contains a required `link` key with the container to link to as a value. By default, the linking container will start and stop in reaction to its target linked containers statuses. 
+An `alias` can also be specified for the container, if not supplied, the default is to use the value of the link key.
+This behaviour can be changed by supplying the `required` key, with the value `False`. This means that we are defining the target container link as non-essential to the running of the linking container.
 This is unlikely to be the behaviour desired in most cases, but may have relevance where the linking container runs a service that will become degraded when the linked-to container is not available, but it is still
 preferable to run a degraded service than run no service at all.
 
@@ -287,7 +288,8 @@ preferable to run a degraded service than run no service at all.
           links:
             - link: container1			# Link to container1, defaults to 'required: True'
             - link: container2			# Link to container2
-              required: False 			# container2 is not required to start this one
+              alias: inner					# (optional) specify the link alias, equivalent to --links container2:inner
+              required: False 			# (optional) container2 is not required to start this one
 ```
 
 ####envvars

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ For more help in resolving problems and errors, see the [Template Deploy Trouble
 - [location](#location)
 - [ports](#ports)
 - [volumes](#volumes)
-- [links_restarts](#links_restarts)
 - [links](#links)
 - [envvars](#envvars)
 - [enable_clustering](#enable_clustering)
@@ -277,16 +276,18 @@ This allows you to mount host volumes in the container.
 ```
 
 
-####links_restarts
-If set to True, the init service jobs are set up to restart and re-link if the linked-to containers restart.
-
 ####links
-This allows the container to be linked to other containers. The first entry in each key is the external container name, the second is the internal name for the container.
+This is a list of container linking entries that allows the container to be linked to other containers.
+Each entry contains a required 'link' key with the container to link to as a value. By default, the linking container will start and stop in reaction to its target linked containers statuses. 
+This behaviour can be changed by supplying the 'required' key, with the value 'False'. This means that we are defining the target container link as non-essential to the running of the linking container.
+This is unlikely to be the behaviour desired in most cases, but may have relevance where the linking container runs a service that will become degraded when the linked-to container is not available, but it is still
+preferable to run a degraded service than run no service at all.
 
 ```yaml
           links:
-	          redis: redis1
-	          hello-external: hello-internal
+            - link: container1			# Link to container1, defaults to 'required: True'
+            - link: container2			# Link to container2
+              required: False 			# container2 is not required to start this one
 ```
 
 ####envvars

--- a/moj-docker-deploy/apps/templates/upstart_branch_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_branch_container.conf
@@ -49,7 +49,7 @@ script
 		{% endif %}
 
 		{% if 'links' in cdata %}
-		LINK_CONTAINERS="{% for link_config in cdata.get('links') %} --link {{ link_config.get('link') }}:{{ link_config.get('link') }} {% endfor %} "
+		LINK_CONTAINERS="{% for link_config in cdata.get('links') %} --link {{ link_config.get('link') }}:{{ link_config.get('alias', link_config.get('link')) }} {% endfor %} "
 		{% endif %}
 
     docker run --name="{{ branch_name }}" {{cdata.get('docker_args', '')}} \

--- a/moj-docker-deploy/apps/templates/upstart_branch_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_branch_container.conf
@@ -72,7 +72,7 @@ pre-start script
 {% for link_config in cdata.get('links') %}
 				for i in $(seq 1 ${max_retry})
         do
-          found_container=$(docker inspect --format='{% raw %}{{.Name}}{% endraw %}' {{ link_config.get('link') }} ) || $(echo "")
+          found_container=$(docker inspect --format='{% raw %}{{.Name}}{% endraw %}' {{ link_config.get('link') }} 2>/dev/null)
           if [ "${found_container}" = "/{{ link_config.get('link') }}" ]; then
           	echo INFO: Found container required for linking ${found_container}...
           	break

--- a/moj-docker-deploy/apps/templates/upstart_branch_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_branch_container.conf
@@ -67,7 +67,7 @@ end script
 # come up before starting, so that we can link to them successfully
 pre-start script
 				{% if 'links' in cdata %}
-				max_retry=5
+				max_retry=10
         echo INFO: Checking if containers required for linking are running...
 {% for link_config in cdata.get('links') %}
 				for i in $(seq 1 ${max_retry})
@@ -95,7 +95,7 @@ end script
 post-start script
     echo INFO: Checking if container {{branch_name}} is running
 	# Test for success
-	max_retry=5
+	max_retry=10
 	for i in $(seq 1 ${max_retry})
 	do
 		RUNNING_ID="`docker ps -q --filter name={{branch_name}}`"

--- a/moj-docker-deploy/apps/templates/upstart_branch_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_branch_container.conf
@@ -5,7 +5,7 @@ author "tools@digital.justice.gov.uk"
 # on the link target container services. If theres no linking, then default
 # to starting when docker starts
 {% if (cdata.get('links', [])|length) > 0 %}
-start on ({% for link_config in cdata.get('links', []) if link_config.get('required', True) %}{% if loop.index > 1 %} and{% endif %} started {{ link_config.get('link') }}_container{% endfor %})
+start on ({% for link_config in cdata.get('links', []) if link_config.get('required', True) %}{% if loop.index > 1 %} or{% endif %} started {{ link_config.get('link') }}_container{% endfor %})
 stop on runlevel [!2345] or ({% for link_config in cdata.get('links', []) if link_config.get('required', True) %}{% if loop.index > 1 %} or{% endif %} stopped {{ link_config.get('link') }}_container{% endfor %})
 {% else %}
 start on filesystem and started docker

--- a/moj-docker-deploy/apps/templates/upstart_branch_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_branch_container.conf
@@ -29,8 +29,8 @@ script
         PORT_OPTS="{% for descr, port_set in cdata['ports'].items() %} -p {{port_set['host']}}:{{port_set['container']}} {% endfor %}"
         {% endif %}
 
-        if [ -f /etc/docker_env.d/{{cname}} ]; then
-                ENV_OPTS="--env-file /etc/docker_env.d/{{cname}}"
+        if [ -f /etc/docker_env.d/{{branch_name}} ]; then
+                ENV_OPTS="--env-file /etc/docker_env.d/{{branch_name}}"
         fi
 
 		# If clustering is enabled for this container, and we have neighbour hosts details are available
@@ -68,22 +68,24 @@ end script
 pre-start script
 				{% if 'links' in cdata %}
 				max_retry=10
-        echo INFO: Checking if containers required for linking are running...
 {% for link_config in cdata.get('links') %}
 				for i in $(seq 1 ${max_retry})
         do
-          found_container=$(docker inspect --format='{% raw %}{{.Name}}{% endraw %}' {{ link_config.get('link') }} 2>/dev/null)
-          if [ "${found_container}" = "/{{ link_config.get('link') }}" ]; then
-          	echo INFO: Found container required for linking ${found_container}...
+        	echo INFO: pre-start: Introspecting a the target link running container named {{ link_config.get('link') }}...
+          found_container=$(docker inspect --format='{% raw %}{{.State.Running}}{% endraw %}' {{ link_config.get('link') }} 2>/dev/null)
+          if [ ${found_container} ]; then
+          	echo INFO: pre-start: Found container required for linking ${found_container}...
           	break
           elif [ "${i}" = "${max_retry}" ]; then
-          	echo CRITICAL: Retry timed out on container required for linking, {{ link_config.get('link') }}, exiting...
+          	echo CRITICAL: pre-start: Retry timed out on container required for linking, {{ link_config.get('link') }}, exiting pre-start with exit code 1...
           	exit 1
           else
-          	echo WARNING: Could not find container required for linking, {{ link_config.get('link') }}, retry ${i}/${max_retry}...
+          	echo WARNING: pre-start: Could not find container required for linking, {{ link_config.get('link') }}, retry ${i}/${max_retry}...
           	sleep 3
           fi
         done
+        echo INFO: pre-start: All target link running containers found, exiting pre-start
+        exit 0
 {% endfor %}
 {% endif%}
 
@@ -93,22 +95,26 @@ end script
 # It uses a small number of retries since the startup of containers
 # is not instantaneous
 post-start script
-    echo INFO: Checking if container {{branch_name}} is running
+    echo INFO: post-start: Checking if container {{branch_name}} is running
 	# Test for success
 	max_retry=10
 	for i in $(seq 1 ${max_retry})
 	do
-		RUNNING_ID="`docker ps -q --filter name={{branch_name}}`"
-		if [ -z ${RUNNING_ID} ]; then
-			echo WARNING: Docker not started yet, retrying...
-			sleep 3
-		else
-			echo INFO: Docker instance has started successfully with id ${RUNNING_ID}
-			exit 0
-		fi
+			echo INFO: post-start: Introspecting for a running container named {{branch_name}}
+		 	found_container=$(docker inspect --format='{% raw %}{{ .State.Running }}{% endraw %}' {{ branch_name }} 2>/dev/null)
+     	if [ ! ${found_container} ]; then
+				echo WARNING: post-start: Docker container {{branch_name}} not started yet, retry ${i}/${max_retry}...
+				sleep 3
+			else
+				echo INFO: post-start: Docker container {{branch_name}} running, exiting...
+				exit 0
+			fi
 	done
 	echo ERROR: Docker failed to start instance
 	exit 1
 end script
 
-post-stop exec docker rm -f {{ branch_name }}
+post-stop script
+				echo INFO: post-stop: Removing docker container {{branch_name}}...
+     		docker rm -f {{ branch_name }} 2>/dev/null
+end script

--- a/moj-docker-deploy/apps/templates/upstart_branch_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_branch_container.conf
@@ -49,7 +49,7 @@ script
 		{% endif %}
 
 		{% if 'links' in cdata %}
-		LINK_CONTAINERS="{% for link_config in cdata.get('links') %} --link {{ link_config.get('link') }} {% endfor %} "
+		LINK_CONTAINERS="{% for link_config in cdata.get('links') %} --link {{ link_config.get('link') }}:{{ link_config.get('link') }} {% endfor %} "
 		{% endif %}
 
     docker run --name="{{ branch_name }}" {{cdata.get('docker_args', '')}} \

--- a/moj-docker-deploy/apps/templates/upstart_branch_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_branch_container.conf
@@ -1,9 +1,19 @@
 description "{{branch_name}} container"
 author "tools@digital.justice.gov.uk"
+
+# If linking is set up on this container then depend the service start/stop
+# on the link target container services. If theres no linking, then default
+# to starting when docker starts
+{% if (cdata.get('links', [])|length) > 0 %}
+start on ({% for link_config in cdata.get('links', []) if link_config.get('required', True) %}{% if loop.index > 1 %} and{% endif %} started {{ link_config.get('link') }}_container{% endfor %})
+stop on runlevel [!2345] or ({% for link_config in cdata.get('links', []) if link_config.get('required', True) %}{% if loop.index > 1 %} or{% endif %} stopped {{ link_config.get('link') }}_container{% endfor %})
+{% else %}
 start on filesystem and started docker
 stop on runlevel [!2345]
+{% endif %}
+
 respawn
-respawn limit 5 5
+respawn limit 5 300
 env HOME=/root
 script
         PILLAR_TAG='{{ tag | replace("'", "'\\''") }}'
@@ -23,7 +33,59 @@ script
                 ENV_OPTS="--env-file /etc/docker_env.d/{{cname}}"
         fi
 
-    docker run --name="{{ branch_name }}" {{cdata.get('docker_args', '')}} $ENV_OPTS -e DB_NAME='{{branch_name}}' -e DOCKER_STATE=create -e DATABASE_URL="{{DATABASE_URL}}" $VOL_OPTS -p {{ cdata['ports']['app']['container'] }} {{branch_container_full}}:"$TAG" {{cdata.get('startup_args', '')}}
+		# If clustering is enabled for this container, and we have neighbour hosts details are available
+		# then add the neighbour and container alias <container_name>.<remote_instance_dns_name> to
+		# the hosts file in the container
+		{% set ec2_neighbours = salt['grains.get']('ec2_neighbours', {}) %}
+		{% set ec2_local_private_dns_name = salt['grains.get']('ec2_local:private_dns_name', '') %}
+		{% set ec2_local_private_dns_name_safe = salt['grains.get']('ec2_local:private_dns_name_safe', '') %}
+
+		{% if 'enable_clustering' in cdata and cdata['enable_clustering'] == True %}
+		HOSTS_OPTS="{% for ip, neighbours in ec2_neighbours.items() %} --add-host={{neighbours['private_dns_name']}}:{{ip}} --add-host={{branch_name}}.{{neighbours['private_dns_name']}}:{{ip}}{% endfor %}"
+		HOSTS_OPTS_SAFE="{% for ip, neighbours in ec2_neighbours.items() %} --add-host={{neighbours['private_dns_name_safe']}}:{{ip}} --add-host={{branch_name}}-{{neighbours['private_dns_name_safe']}}:{{ip}}{% endfor %}"
+		CLUSTER_NODES="[ {% for ip, neighbours in ec2_neighbours.items() %} '{{branch_name}}.{{neighbours['private_dns_name']}}'{% if not loop.last %},{% endif %} {% endfor %}]"
+		CLUSTER_NODES_SAFE="[{% for ip, neighbours in ec2_neighbours.items() %} '{{branch_name}}-{{neighbours['private_dns_name_safe']}}'{% if not loop.last %},{% endif %} {% endfor %}]"
+		HOSTNAME_OPTS=" -h {{branch_name}}-{{ec2_local_private_dns_name_safe}} "
+		{% endif %}
+
+		{% if 'links' in cdata %}
+		LINK_CONTAINERS="{% for link_config in cdata.get('links') %} --link {{ link_config.get('link') }} {% endfor %} "
+		{% endif %}
+
+    docker run --name="{{ branch_name }}" {{cdata.get('docker_args', '')}} \
+    	${LINK_CONTAINERS} \
+    	-e "CLUSTER_NODES=${CLUSTER_NODES}" \
+    	-e "CLUSTER_NODES_SAFE=${CLUSTER_NODES_SAFE}" \
+    	-e DB_NAME='{{branch_name}}' \
+    	-e DOCKER_STATE=create \
+    	-e DATABASE_URL="{{DATABASE_URL}}" \
+    	${HOSTNAME_OPTS} ${HOSTS_OPTS} ${HOSTS_OPTS_SAFE} ${ENV_OPTS} ${VOL_OPTS} ${PORT_OPTS} {{branch_container_full}}:"$TAG" {{cdata.get('startup_args', '')}}
+
+end script
+
+# Pre start check makes sure that we retry a few times to allow any linked containers to
+# come up before starting, so that we can link to them successfully
+pre-start script
+				{% if 'links' in cdata %}
+				max_retry=5
+        echo INFO: Checking if containers required for linking are running...
+{% for link_config in cdata.get('links') %}
+				for i in $(seq 1 ${max_retry})
+        do
+          found_container=$(docker inspect --format='{% raw %}{{.Name}}{% endraw %}' {{ link_config.get('link') }} ) || $(echo "")
+          if [ "${found_container}" = "/{{ link_config.get('link') }}" ]; then
+          	echo INFO: Found container required for linking ${found_container}...
+          	break
+          elif [ "${i}" = "${max_retry}" ]; then
+          	echo CRITICAL: Retry timed out on container required for linking, {{ link_config.get('link') }}, exiting...
+          	exit 1
+          else
+          	echo WARNING: Could not find container required for linking, {{ link_config.get('link') }}, retry ${i}/${max_retry}...
+          	sleep 3
+          fi
+        done
+{% endfor %}
+{% endif%}
 
 end script
 
@@ -33,7 +95,8 @@ end script
 post-start script
     echo INFO: Checking if container {{branch_name}} is running
 	# Test for success
-	for i in {1..5}
+	max_retry=5
+	for i in $(seq 1 ${max_retry})
 	do
 		RUNNING_ID="`docker ps -q --filter name={{branch_name}}`"
 		if [ -z ${RUNNING_ID} ]; then

--- a/moj-docker-deploy/apps/templates/upstart_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_container.conf
@@ -1,9 +1,12 @@
 description "{{cname}} container"
 author "tools@digital.justice.gov.uk"
 
-{% if 'links' in cdata and cdata.get('links_restarts', False) %}
-start on ({% for linked_container_external, linked_container_internal in cdata.get('links').iteritems() %}{% if loop.index > 1 %} or{% endif %} started {{ linked_container_external }}_container{% endfor %})
-stop on runlevel [!2345] or ({% for linked_container_external, linked_container_internal in cdata.get('links').iteritems() %}{% if loop.index > 1 %} or{% endif %} stopped {{ linked_container_external }}_container{% endfor %})
+# If linking is set up on this container then depend the service start/stop
+# on the link target container services. If theres no linking, then default
+# to starting when docker starts
+{% if (cdata.get('links', [])|length) > 0 %}
+start on ({% for link_config in cdata.get('links', []) if link_config.get('required', True) %}{% if loop.index > 1 %} and{% endif %} started {{ link_config.get('link') }}_container{% endfor %})
+stop on runlevel [!2345] or ({% for link_config in cdata.get('links', []) if link_config.get('required', True) %}{% if loop.index > 1 %} or{% endif %} stopped {{ link_config.get('link') }}_container{% endfor %})
 {% else %}
 start on filesystem and started docker
 stop on runlevel [!2345]
@@ -46,7 +49,7 @@ script
 		{% endif %}
 
 		{% if 'links' in cdata %}
-		LINK_CONTAINERS="{% for linked_container_external, linked_container_internal in cdata.get('links').iteritems() %} --link {{ linked_container_external }}:{{ linked_container_internal }} {% endfor %} "
+		LINK_CONTAINERS="{% for link_config in cdata.get('links') %} --link {{ link_config.get('link') }} {% endfor %} "
 		{% endif %}
 
     docker run --name="{{ cname }}" {{cdata.get('docker_args', '')}} \
@@ -57,30 +60,30 @@ script
 
 end script
 
-# Pre start check makes sure that we retry a few times to allow any linked containers to 
+# Pre start check makes sure that we retry a few times to allow any linked containers to
 # come up before starting, so that we can link to them successfully
 pre-start script
 				{% if 'links' in cdata %}
 				max_retry=5
         echo INFO: Checking if containers required for linking are running...
-{% for linked_container_external, linked_container_internal in cdata.get('links').iteritems() %}
+{% for link_config in cdata.get('links') %}
 				for i in $(seq 1 ${max_retry})
         do
-          found_container=$(docker inspect --format='{% raw %}{{.Name}}{% endraw %}' {{ linked_container_external }} ) || $(echo "")
-          if [ "${found_container}" = "/{{ linked_container_external }}" ]; then
+          found_container=$(docker inspect --format='{% raw %}{{.Name}}{% endraw %}' {{ link_config.get('link') }} ) || $(echo "")
+          if [ "${found_container}" = "/{{ link_config.get('link') }}" ]; then
           	echo INFO: Found container required for linking ${found_container}...
           	break
           elif [ "${i}" = "${max_retry}" ]; then
-          	echo CRITICAL: Retry timed out on container required for linking, {{ linked_container_external }}, exiting...
+          	echo CRITICAL: Retry timed out on container required for linking, {{ link_config.get('link') }}, exiting...
           	exit 1
           else
-          	echo WARNING: Could not find container required for linking, {{ linked_container_external }}, retry ${i}/${max_retry}...
+          	echo WARNING: Could not find container required for linking, {{ link_config.get('link') }}, retry ${i}/${max_retry}...
           	sleep 3
           fi
         done
 {% endfor %}
 {% endif%}
-     
+
 end script
 
 # Post start script checks that the container it actually running

--- a/moj-docker-deploy/apps/templates/upstart_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_container.conf
@@ -65,22 +65,24 @@ end script
 pre-start script
 				{% if 'links' in cdata %}
 				max_retry=10
-        echo INFO: Checking if containers required for linking are running...
 {% for link_config in cdata.get('links') %}
 				for i in $(seq 1 ${max_retry})
         do
-          found_container=$(docker inspect --format='{% raw %}{{.Name}}{% endraw %}' {{ link_config.get('link') }} 2>/dev/null)
-          if [ "${found_container}" = "/{{ link_config.get('link') }}" ]; then
-          	echo INFO: Found container required for linking ${found_container}...
+        	echo INFO: pre-start: Introspecting a the target link running container named {{ link_config.get('link') }}...
+          found_container=$(docker inspect --format='{% raw %}{{.State.Running}}{% endraw %}' {{ link_config.get('link') }} 2>/dev/null)
+          if [ ${found_container} ]; then
+          	echo INFO: pre-start: Found container required for linking ${found_container}...
           	break
           elif [ "${i}" = "${max_retry}" ]; then
-          	echo CRITICAL: Retry timed out on container required for linking, {{ link_config.get('link') }}, exiting...
+          	echo CRITICAL: pre-start: Retry timed out on container required for linking, {{ link_config.get('link') }}, exiting pre-start with exit code 1...
           	exit 1
           else
-          	echo WARNING: Could not find container required for linking, {{ link_config.get('link') }}, retry ${i}/${max_retry}...
+          	echo WARNING: pre-start: Could not find container required for linking, {{ link_config.get('link') }}, retry ${i}/${max_retry}...
           	sleep 3
           fi
         done
+        echo INFO: pre-start: All target link running containers found, exiting pre-start
+        exit 0
 {% endfor %}
 {% endif%}
 
@@ -90,22 +92,26 @@ end script
 # It uses a small number of retries since the startup of containers
 # is not instantaneous
 post-start script
-    echo INFO: Checking if container {{cname}} is running
+    echo INFO: post-start: Checking if container {{cname}} is running
 	# Test for success
 	max_retry=10
 	for i in $(seq 1 ${max_retry})
 	do
-		RUNNING_ID="`docker ps -q --filter name={{cname}}`"
-		if [ -z ${RUNNING_ID} ]; then
-			echo WARNING: Docker not started yet, retrying...
-			sleep 3
-		else
-			echo INFO: Docker instance has started successfully with id ${RUNNING_ID}
-			exit 0
-		fi
+			echo INFO: post-start: Introspecting for a running container named {{cname}}
+		 	found_container=$(docker inspect --format='{% raw %}{{ .State.Running }}{% endraw %}' {{ cname }} 2>/dev/null)
+     	if [ ! ${found_container} ]; then
+				echo WARNING: post-start: Docker container {{cname}} not started yet, retry ${i}/${max_retry}...
+				sleep 3
+			else
+				echo INFO: post-start: Docker container {{cname}} running, exiting...
+				exit 0
+			fi
 	done
 	echo ERROR: Docker failed to start instance
 	exit 1
 end script
 
-post-stop exec docker rm -f {{ cname }}
+post-stop script
+				echo INFO: post-stop: Removing docker container {{cname}}...
+     		docker rm -f {{ cname }} 2>/dev/null
+end script

--- a/moj-docker-deploy/apps/templates/upstart_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_container.conf
@@ -49,7 +49,7 @@ script
 		{% endif %}
 
 		{% if 'links' in cdata %}
-		LINK_CONTAINERS="{% for link_config in cdata.get('links') %} --link {{ link_config.get('link') }}:{{ link_config.get('link') }} {% endfor %} "
+		LINK_CONTAINERS="{% for link_config in cdata.get('links') %} --link {{ link_config.get('link') }}:{{ link_config.get('alias', link_config.get('link')) }} {% endfor %} "
 		{% endif %}
 
     docker run --name="{{ cname }}" {{cdata.get('docker_args', '')}} \

--- a/moj-docker-deploy/apps/templates/upstart_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_container.conf
@@ -69,7 +69,7 @@ pre-start script
 {% for link_config in cdata.get('links') %}
 				for i in $(seq 1 ${max_retry})
         do
-          found_container=$(docker inspect --format='{% raw %}{{.Name}}{% endraw %}' {{ link_config.get('link') }} ) || $(echo "")
+          found_container=$(docker inspect --format='{% raw %}{{.Name}}{% endraw %}' {{ link_config.get('link') }} 2>/dev/null)
           if [ "${found_container}" = "/{{ link_config.get('link') }}" ]; then
           	echo INFO: Found container required for linking ${found_container}...
           	break

--- a/moj-docker-deploy/apps/templates/upstart_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_container.conf
@@ -5,7 +5,7 @@ author "tools@digital.justice.gov.uk"
 # on the link target container services. If theres no linking, then default
 # to starting when docker starts
 {% if (cdata.get('links', [])|length) > 0 %}
-start on ({% for link_config in cdata.get('links', []) if link_config.get('required', True) %}{% if loop.index > 1 %} and{% endif %} started {{ link_config.get('link') }}_container{% endfor %})
+start on ({% for link_config in cdata.get('links', []) if link_config.get('required', True) %}{% if loop.index > 1 %} or{% endif %} started {{ link_config.get('link') }}_container{% endfor %})
 stop on runlevel [!2345] or ({% for link_config in cdata.get('links', []) if link_config.get('required', True) %}{% if loop.index > 1 %} or{% endif %} stopped {{ link_config.get('link') }}_container{% endfor %})
 {% else %}
 start on filesystem and started docker

--- a/moj-docker-deploy/apps/templates/upstart_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_container.conf
@@ -64,7 +64,7 @@ end script
 # come up before starting, so that we can link to them successfully
 pre-start script
 				{% if 'links' in cdata %}
-				max_retry=5
+				max_retry=10
         echo INFO: Checking if containers required for linking are running...
 {% for link_config in cdata.get('links') %}
 				for i in $(seq 1 ${max_retry})
@@ -92,7 +92,7 @@ end script
 post-start script
     echo INFO: Checking if container {{cname}} is running
 	# Test for success
-	max_retry=5
+	max_retry=10
 	for i in $(seq 1 ${max_retry})
 	do
 		RUNNING_ID="`docker ps -q --filter name={{cname}}`"

--- a/moj-docker-deploy/apps/templates/upstart_container.conf
+++ b/moj-docker-deploy/apps/templates/upstart_container.conf
@@ -49,7 +49,7 @@ script
 		{% endif %}
 
 		{% if 'links' in cdata %}
-		LINK_CONTAINERS="{% for link_config in cdata.get('links') %} --link {{ link_config.get('link') }} {% endfor %} "
+		LINK_CONTAINERS="{% for link_config in cdata.get('links') %} --link {{ link_config.get('link') }}:{{ link_config.get('link') }} {% endfor %} "
 		{% endif %}
 
     docker run --name="{{ cname }}" {{cdata.get('docker_args', '')}} \


### PR DESCRIPTION
The current structure is a little unclear, this change will rewrite the
required pillar structure in the format.

```
links:
  - link: sidekiq
    required: True
```

This will also alter the behaviour of the container service, by default
'required' will be true, meaning that the linking container will not
be started unless all of its link target containers are available.

If 'required' is set to False this means that we are defining the target
container link as non-essential to the running of the linking container.
This is unlikely to be the behaviour desired in most cases, but may have
relevance where the linking container runs a service that will become
degraded when the linked-to container is not available, but it is still
preferable to run a degraded service than run no service at all.
