### PR TITLE
Add option to disable STS for a container

### DIFF
--- a/moj-docker-deploy/apps/templates/nginx_container.conf
+++ b/moj-docker-deploy/apps/templates/nginx_container.conf
@@ -46,7 +46,11 @@ server {
         if ($http_x_forwarded_proto != 'https') {
                 rewrite ^ https://$host$request_uri? permanent;
         }
+
+        {% if not cdata.get('disable_sts', False) %} 
         add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+        {% endif %}
+
         {% endif %}
 
 	{% if cdata.get('basic_auth', False) %}
@@ -91,7 +95,9 @@ server {
         if ($http_x_forwarded_proto != 'https') {
                 rewrite ^ https://$host$request_uri? permanent;
         }
+
         add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+
         {% endif %}
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Often dev/staging environments re-use the production certificate which
leads to the site being inaccessible in Chrome if the strict transport
security header is set.  This commit gives us the option of removing the
STS header for non production environments.