### PR TITLE
Backport fix preventing exception during dockerng.list_tags

### DIFF
--- a/_modules/dockerng.py
+++ b/_modules/dockerng.py
@@ -2078,7 +2078,7 @@ def images(verbose=False, **kwargs):
                 continue
             for item in img:
                 img_state = 'untagged' \
-                    if img['RepoTags'] == ['<none>:<none>'] \
+                    if img['RepoTags'] in (['<none>:<none>'], None) \
                     else 'tagged'
                 bucket = __context__.setdefault('docker.images', {})
                 bucket = bucket.setdefault(img_state, {})
@@ -2259,8 +2259,9 @@ def list_tags():
     '''
     ret = set()
     for item in six.itervalues(images()):
-        for repo_tag in item['RepoTags']:
-            ret.add(repo_tag)
+        if not item.get('RepoTags'):
+            continue
+        ret.update(set(item['RepoTags']))
     return sorted(ret)
 
 


### PR DESCRIPTION
Fixes #62.

Relevant upstream commits:
saltstack/salt@49af3304926d632a9070a7c37566949d4f56ffeb
saltstack/salt@fbc88b23ae585bd7c2147f7bcbbefadd02339fb4

Note: I was not able to reproduce the issue with our current version of docker though.