### PR TITLE
Sleep after start to fix race condition between docker/upstart

### DIFF
--- a/moj-docker-deploy/apps/libs.sls
+++ b/moj-docker-deploy/apps/libs.sls
@@ -47,6 +47,9 @@
     - require_in:
       - file: /etc/nginx/conf.d/{{ server_name }}.conf
 {% endif %}
+    - check_cmd:
+        - sleep {{ cdata.get('initial_delay', 1)}} && docker inspect {{ container }}
+
 {% endmacro %}
 
 # Macro to register and de-register a container with elbs


### PR DESCRIPTION
**Sleep after start to fix race condition between docker/upstart**

Upstart is async. Issuing a service sth start/restart/stop doesn't guarantee that the service is started/restarted/stopped after the service command returns. Inspecting for the container after service.running ran is a good indication for success/failure.

Also and as suggested by @filipposc5 this could be performed using a more elaborate form of healthchecking, e.g. request the container's healthcheck/ping.json endpoint with a retry mechanism before declaring failure. 

However with this PR, I've opted with something very simple that can work everywhere without relying on container specific things (running an HTTP interface and having a healthcheck/ping endpoint, etc).  Hopefully it fixes the dreaded HostPort issue.




